### PR TITLE
user id issues

### DIFF
--- a/python-tox/Dockerfile
+++ b/python-tox/Dockerfile
@@ -2,9 +2,13 @@ FROM fedora:33
 
 LABEL maintainer "Brian Stinson <brian@bstinson.com>"
 
-RUN dnf -y install python3-tox krb5-devel popt-devel python3-devel rpm-devel @c-development git poetry openssl-devel libcurl-devel openldap-devel npm libffi-devel
+RUN dnf -y install python3-tox krb5-devel popt-devel python3-devel rpm-devel @c-development git poetry openssl-devel libcurl-devel openldap-devel npm libffi-devel rpm-build
 
 RUN chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME
+
+COPY uid_entrypoint /uid_entrypoint
+
+RUN chmod g=u /etc/passwd
 
 USER 1001

--- a/python-tox/uid_entrypoint
+++ b/python-tox/uid_entrypoint
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec "$@"


### PR DESCRIPTION
RPKG tests were facing some issues while getting the current user id - this was caused by the fact the `1001` user was missing in `/etc/passwd`.

User changes were based on openshift docs: https://docs.openshift.com/container-platform/3.3/creating_images/guidelines.html#openshift-container-platform-specific-guidelines

## Changes

* changes /etc/passwd permissions
* a script that adds the current user into /etc/passwd file in "nologin" mode
* "rpm-build" rpm package

## Tests

* run the container: `docker run -it --entrypoint /bin/bash  -e HOME=/tmp quay.io/lrossett/python-tox:f33`
* run `/uid_entrypoint` and then `cat /etc/passwd` to check if user `1001` was added into the file
* `cd /tmp`
* `mkdir .openidc`
* `git clone https://pagure.io/forks/lrossett/rpkg.git`
* `tox -e py36`