### PR TITLE
Add a couple more utilities to the C8S cico-workspace image

### DIFF
--- a/cico-workspace/Dockerfile
+++ b/cico-workspace/Dockerfile
@@ -10,7 +10,7 @@ RUN rpm -ivh --nodeps --replacefiles *.rpm && rm *.rpm \
     && rpm -e redhat-release \
     && dnf --setopt=tsflags=nodocs --setopt=install_weak_deps=false -y distro-sync \
     && dnf remove -y subscription-manager dnf-plugin-subscription-manager\
-    && dnf install -y glibc-langpack-en \
+    && dnf install -y glibc-langpack-en iputils tree \
     && dnf clean all
 
 COPY infrastructure.repo /etc/yum.repos.d/


### PR DESCRIPTION
Both `ping` and `tree` were present in the original C7 cico-workspace
image, so let's include them in the new image as well.

Signed-off-by: Frantisek Sumsal <frantisek@sumsal.cz>

/cc @arrfab 